### PR TITLE
wire-desktop: compile native extensions against correct electron version

### DIFF
--- a/wire-desktop-beta/.SRCINFO
+++ b/wire-desktop-beta/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wire-desktop-beta
 	pkgdesc = End-to-end encrypted messenger with file sharing, voice calls and video conferences
 	pkgver = 3.5.2881
-	pkgrel = 2
+	pkgrel = 3
 	url = https://wire.com/
 	arch = x86_64
 	license = GPL3

--- a/wire-desktop-git/.SRCINFO
+++ b/wire-desktop-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wire-desktop-git
 	pkgdesc = End-to-end encrypted messenger with file sharing, voice calls and video conferences
 	pkgver = 3.5.2881.r14.g2b7ce57f
-	pkgrel = 1
+	pkgrel = 2
 	url = https://wire.com/
 	arch = x86_64
 	license = GPL3

--- a/wire-desktop/.SRCINFO
+++ b/wire-desktop/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = wire-desktop
 	pkgdesc = End-to-end encrypted messenger with file sharing, voice calls and video conferences
 	pkgver = 3.5.2881
-	pkgrel = 2
+	pkgrel = 3
 	url = https://wire.com/
 	arch = x86_64
 	license = GPL3

--- a/wire-desktop/PKGBUILD
+++ b/wire-desktop/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=wire-desktop
 pkgver=3.5.2881
-pkgrel=2
+pkgrel=3
 pkgdesc='End-to-end encrypted messenger with file sharing, voice calls and video conferences'
 arch=('x86_64')
 url='https://wire.com/'
@@ -18,11 +18,16 @@ sha256sums=('4216cd9c3a2c4920aec2f3c967181b04bfafdb1b47e526a8e823911cce704da1'
             'cc9056cecff2aa49a9ce9c8376d57ec8c7c2cb8174f7966b5cdccbeb2e3751ea')
 
 prepare() {
+  # Ensure we compile native extensions against system electron version
+  local electronver="$(pacman -Q electron | cut -d' ' -f2 | cut -d'-' -f1)"
+  msg2 "Compiling against system electron version: $electronver"
+  sed -i 's/"electron": ".*"/"electron": "'"$electronver"'"/' "${pkgname}-linux-${pkgver}/package.json"
+
   # Create launcher script
   cat << EOF > "${pkgname}"
 #!/bin/sh
 
-electron "/usr/lib/${pkgname}"
+electron "/usr/lib/${pkgname}" "\$@"
 EOF
 }
 
@@ -30,13 +35,13 @@ build() {
   cd "${pkgname}-linux-${pkgver}"
   yarn
   yarn build:ts
-  npx grunt 'linux-other'
+  npx grunt 'clean:linux' 'update-keys' 'gitinfo' 'release-prod' 'bundle'
 }
 
 package() {
   # Place files
   install -d "${pkgdir}/usr/lib/${pkgname}"
-  cp -a "${pkgname}-linux-${pkgver}"/wrap/dist/linux-unpacked/resources/app/* "${pkgdir}/usr/lib/${pkgname}"
+  cp -a "${pkgname}-linux-${pkgver}/electron/"* "${pkgdir}/usr/lib/${pkgname}"
 
   # Place launcher script
   install -Dm755 -t "${pkgdir}/usr/bin/" "${pkgname}"
@@ -51,10 +56,4 @@ package() {
   # Spellcheck dictionaries
   rm -rf "${pkgdir}/usr/lib/${pkgname}/node_modules/spellchecker/vendor/hunspell_dictionaries"
   ln -s "/usr/share/hunspell" "${pkgdir}/usr/lib/${pkgname}/node_modules/spellchecker/vendor/hunspell_dictionaries"
-
-  # Place license files
-  local license
-  for license in "LICENSE.electron.txt" "LICENSES.chromium.html"; do
-    install -Dm644 "${pkgname}-linux-${pkgver}/wrap/dist/linux-unpacked/${license}" "${pkgdir}/usr/share/licenses/${pkgname}/${license}"
-  done
 }


### PR DESCRIPTION
- Compile native extensions against system electron
- Propagate CLI arguments
- Do not use electronbuilder at all
- Do not install Electron's license files
